### PR TITLE
implement attention parsing.

### DIFF
--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -355,6 +355,7 @@ impl ::core::fmt::Debug for Time {
 pub type Signature<'i> = OctetStr<'i>;
 
 /// Procedere parameter value
+/// Not supported now.
 #[derive(PartialEq, Debug, Eq, Clone)]
 pub enum ProcParValue {
     /// value
@@ -370,6 +371,19 @@ pub enum ProcParValue {
 }
 
 impl<'i> SmlParseTlf<'i> for ProcParValue {
+    fn check_tlf(_tlf: &TypeLengthField) -> bool {
+        false
+    }
+
+    fn parse_with_tlf(_input: &'i [u8], _tlf: &TypeLengthField) -> ResTy<'i, Self> {
+        Err(ParseError::NotSupported)
+    }
+}
+
+/// Child trees are not supported now.
+#[derive(PartialEq, Debug, Eq, Clone)]
+pub struct UnsupportedTree();
+impl<'i> SmlParseTlf<'i> for UnsupportedTree {
     fn check_tlf(_tlf: &TypeLengthField) -> bool {
         false
     }
@@ -395,7 +409,7 @@ pub struct Tree<'i> {
     /// Value
     pub parameter_value: Option<ProcParValue>,
     /// The child list.
-    pub child_list: Box<Option<Self>>,
+    pub child_list: Option<UnsupportedTree>,
 }
 
 impl<'i> SmlParseTlf<'i> for Tree<'i> {
@@ -406,12 +420,12 @@ impl<'i> SmlParseTlf<'i> for Tree<'i> {
     fn parse_with_tlf(input: &'i [u8], _tlf: &TypeLengthField) -> ResTy<'i, Self> {
         let (input, parameter_name) = <OctetStr<'i>>::parse(input)?;
         let (input, parameter_value) = <Option<ProcParValue>>::parse(input)?;
-        let (input, child_list) = <Option<Tree<'i>>>::parse(input)?;
+        let (input, child_list) = <Option<UnsupportedTree>>::parse(input)?;
 
         let val = Self {
             parameter_name,
             parameter_value,
-            child_list: Box::new(child_list),
+            child_list,
         };
 
         Ok((input, val))

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -654,13 +654,14 @@ pub enum AttentionNumber<'i> {
 
 impl<'i> From<OctetStr<'i>> for AttentionNumber<'i> {
     fn from(value: OctetStr<'i>) -> Self {
-        if value >= &[0x81, 0x81, 0xC7, 0xC7, 0xE0, 0x00]
-            && value <= &[0x81, 0x81, 0xC7, 0xC7, 0xFC, 0xFF]
-        {
+        let lower_application_specific: &[u8] = &[0x81, 0x81, 0xC7, 0xC7, 0xE0, 0x00];
+        let upper_application_specific: &[u8] = &[0x81, 0x81, 0xC7, 0xC7, 0xFC, 0xFF];
+        let lower_hintnumber: &[u8] = &[0x81, 0x81, 0xC7, 0xC7, 0xFD, 0x00];
+        let upper_hintnumber: &[u8] = &[0x81, 0x81, 0xC7, 0xC7, 0xFD, 0xFF];
+
+        if (lower_application_specific..=upper_application_specific).contains(&value) {
             Self::ApplicationSpecific(ApplicationSpecific(value))
-        } else if value >= &[0x81, 0x81, 0xC7, 0xC7, 0xFD, 0x00]
-            && value <= &[0x81, 0x81, 0xC7, 0xC7, 0xFD, 0xFF]
-        {
+        } else if (lower_hintnumber..=upper_hintnumber).contains(&value) {
             Self::HintNumber(HintNumber::from(value))
         } else {
             Self::AttentionErrorCode(AttentionErrorCode::from(value))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -142,6 +142,8 @@ pub enum ParseError {
     MsgEndMismatch,
     /// Got a variant id that isn't known. This means it's either invalid or not supported (yet) by the parser
     UnexpectedVariant,
+    /// Not supported
+    NotSupported,
 }
 
 impl fmt::Display for ParseError {

--- a/src/parser/streaming.rs
+++ b/src/parser/streaming.rs
@@ -5,7 +5,7 @@
 use crate::util::CRC_X25;
 
 use super::{
-    common::{CloseResponse, EndOfSmlMessage, ListEntry, OpenResponse, Signature, Time},
+    common::{AttentionResponse, CloseResponse, EndOfSmlMessage, ListEntry, OpenResponse, Signature, Time},
     octet_string::OctetStr,
     tlf::{self, Ty, TypeLengthField},
     OctetStrFormatter, ParseError, ResTy, SmlParse, SmlParseTlf,
@@ -174,6 +174,8 @@ pub enum MessageBody<'i> {
     CloseResponse(CloseResponse<'i>),
     /// Start of the `SML_GetList.Res` message
     GetListResponse(GetListResponseStart<'i>),
+    /// Start of the `Attention.Res` message
+    AttentionResponse(AttentionResponse<'i>),
 }
 
 impl<'i> core::fmt::Debug for MessageBody<'i> {
@@ -182,6 +184,7 @@ impl<'i> core::fmt::Debug for MessageBody<'i> {
             Self::OpenResponse(arg0) => arg0.fmt(f),
             Self::CloseResponse(arg0) => arg0.fmt(f),
             Self::GetListResponse(arg0) => arg0.fmt(f),
+            Self::AttentionResponse(arg0) => arg0.fmt(f),
         }
     }
 }
@@ -205,6 +208,10 @@ impl<'i> SmlParseTlf<'i> for MessageBody<'i> {
             0x00000701 => {
                 let (input, x) = <GetListResponseStart<'i>>::parse(input)?;
                 Ok((input, MessageBody::GetListResponse(x)))
+            }
+            0x0000FF01 => {
+                let (input, x) = <AttentionResponse<'i>>::parse(input)?;
+                Ok((input, MessageBody::AttentionResponse(x)))
             }
             _ => Err(ParseError::UnexpectedVariant),
         }

--- a/src/parser/streaming.rs
+++ b/src/parser/streaming.rs
@@ -5,7 +5,9 @@
 use crate::util::CRC_X25;
 
 use super::{
-    common::{AttentionResponse, CloseResponse, EndOfSmlMessage, ListEntry, OpenResponse, Signature, Time},
+    common::{
+        AttentionResponse, CloseResponse, EndOfSmlMessage, ListEntry, OpenResponse, Signature, Time,
+    },
     octet_string::OctetStr,
     tlf::{self, Ty, TypeLengthField},
     OctetStrFormatter, ParseError, ResTy, SmlParse, SmlParseTlf,

--- a/tests/libsml-testing.rs
+++ b/tests/libsml-testing.rs
@@ -72,3 +72,146 @@ fn test_files() {
         insta::assert_snapshot!(s);
     });
 }
+
+#[cfg(test)]
+mod test_attention_response {
+    use sml_rs::parser::{
+        common::{
+            AttentionErrorCode, AttentionNumber, AttentionResponse, CloseResponse, HintNumber,
+            OpenResponse, Time, Tree,
+        },
+        streaming::{self, MessageBody, MessageStart, ParseEvent},
+    };
+
+    #[test]
+    fn attention_response_order_not_executed() {
+        let bytes = vec![
+            0x1B, 0x1B, 0x1B, 0x1B, 0x01, 0x01, 0x01, 0x01, 0x76, 0x02, 0x01, 0x62, 0x00, 0x62,
+            0x00, 0x72, 0x63, 0x01, 0x01, 0x76, 0x01, 0x07, 0x43, 0x4C, 0x4E, 0x49, 0x44, 0x31,
+            0x0A, 0x51, 0x00, 0x00, 0x00, 0x00, 0x66, 0x9F, 0x41, 0xA7, 0x0B, 0x0A, 0x01, 0x4C,
+            0x47, 0x5A, 0x00, 0x03, 0xA9, 0xC6, 0x26, 0x72, 0x62, 0x01, 0x65, 0x00, 0x08, 0x5A,
+            0xE0, 0x01, 0x63, 0x31, 0x66, 0x00, 0x76, 0x02, 0x02, 0x62, 0x00, 0x62, 0x00, 0x72,
+            0x63, 0xFF, 0x01, 0x74, 0x0B, 0x0A, 0x01, 0x4C, 0x47, 0x5A, 0x00, 0x03, 0xA9, 0xC6,
+            0x26, 0x07, 0x81, 0x81, 0xC7, 0xC7, 0xFE, 0x0A, 0x01, 0x73, 0x0A, 0x01, 0x00, 0x5E,
+            0x31, 0x00, 0x07, 0x00, 0x01, 0x00, 0x01, 0x01, 0x63, 0x5C, 0xF4, 0x00, 0x76, 0x02,
+            0x03, 0x62, 0x00, 0x62, 0x00, 0x72, 0x63, 0x02, 0x01, 0x71, 0x01, 0x63, 0xD5, 0x35,
+            0x00, 0x00, 0x1B, 0x1B, 0x1B, 0x1B, 0x1A, 0x01, 0xC4, 0x75,
+        ];
+        let mut decoder =
+            sml_rs::transport::decode_streaming::<sml_rs::util::ArrayBuf<2048>>(bytes);
+        let expected_response = vec![
+            MessageStart {
+                transaction_id: &[1],
+                group_no: 0,
+                abort_on_error: 0,
+                message_body: MessageBody::OpenResponse(OpenResponse {
+                    client_id: Some(&[67, 76, 78, 73, 68, 49]),
+                    req_file_id: &[81, 0, 0, 0, 0, 102, 159, 65, 167],
+                    codepage: None,
+                    server_id: &[10, 1, 76, 71, 90, 0, 3, 169, 198, 38],
+                    ref_time: Some(Time::SecIndex(547552)),
+                    sml_version: None,
+                }),
+            },
+            MessageStart {
+                transaction_id: &[2],
+                group_no: 0,
+                abort_on_error: 0,
+                message_body: MessageBody::AttentionResponse(AttentionResponse {
+                    server_id: &[10, 1, 76, 71, 90, 0, 3, 169, 198, 38],
+                    number: AttentionNumber::AttentionErrorCode(
+                        AttentionErrorCode::OrderNotExecuted,
+                    ),
+                    msg: None,
+                    details: Some(Tree {
+                        parameter_name: &[0x01, 0x00, 0x5E, 0x31, 0x00, 0x07, 0x00, 0x01, 0x00],
+                        parameter_value: None,
+                        child_list: Box::new(None),
+                    }),
+                }),
+            },
+            MessageStart {
+                transaction_id: &[3],
+                group_no: 0,
+                abort_on_error: 0,
+                message_body: MessageBody::CloseResponse(CloseResponse {
+                    global_signature: None,
+                }),
+            },
+        ];
+        while let Some(result) = decoder.next() {
+            let input = result.unwrap();
+            let parser = streaming::Parser::new(input);
+            for (idx, val) in parser.enumerate().into_iter() {
+                if let Ok(ParseEvent::MessageStart(val)) = val {
+                    assert_eq!(expected_response[idx], val);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn attention_response_positive() {
+        let bytes = vec![
+            0x1B, 0x1B, 0x1B, 0x1B, 0x01, 0x01, 0x01, 0x01, 0x76, 0x02, 0x01, 0x62, 0x00, 0x62,
+            0x00, 0x72, 0x63, 0x01, 0x01, 0x76, 0x01, 0x07, 0x43, 0x4C, 0x4E, 0x49, 0x44, 0x31,
+            0x0A, 0x51, 0x00, 0x00, 0x00, 0x00, 0x66, 0x9F, 0x64, 0x3C, 0x0B, 0x0A, 0x01, 0x4C,
+            0x47, 0x5A, 0x00, 0x03, 0xA9, 0xC6, 0x26, 0x72, 0x62, 0x01, 0x65, 0x00, 0x08, 0x7D,
+            0x56, 0x01, 0x63, 0xC2, 0xF2, 0x00, 0x76, 0x02, 0x02, 0x62, 0x00, 0x62, 0x00, 0x72,
+            0x63, 0xFF, 0x01, 0x74, 0x0B, 0x0A, 0x01, 0x4C, 0x47, 0x5A, 0x00, 0x03, 0xA9, 0xC6,
+            0x26, 0x07, 0x81, 0x81, 0xC7, 0xC7, 0xFD, 0x00, 0x01, 0x73, 0x0A, 0x01, 0x00, 0x5E,
+            0x31, 0x00, 0x07, 0x00, 0x01, 0x00, 0x01, 0x01, 0x63, 0x5B, 0xAF, 0x00, 0x76, 0x02,
+            0x03, 0x62, 0x00, 0x62, 0x00, 0x72, 0x63, 0x02, 0x01, 0x71, 0x01, 0x63, 0xD5, 0x35,
+            0x00, 0x00, 0x1B, 0x1B, 0x1B, 0x1B, 0x1A, 0x01, 0xAC, 0x0C,
+        ];
+        let expected_response = vec![
+            MessageStart {
+                transaction_id: &[1],
+                group_no: 0,
+                abort_on_error: 0,
+                message_body: MessageBody::OpenResponse(OpenResponse {
+                    client_id: Some(&[67, 76, 78, 73, 68, 49]),
+                    req_file_id: &[81, 0, 0, 0, 0, 102, 159, 100, 60],
+                    codepage: None,
+                    server_id: &[10, 1, 76, 71, 90, 0, 3, 169, 198, 38],
+                    ref_time: Some(Time::SecIndex(556374)),
+                    sml_version: None,
+                }),
+            },
+            MessageStart {
+                transaction_id: &[2],
+                group_no: 0,
+                abort_on_error: 0,
+                message_body: MessageBody::AttentionResponse(AttentionResponse {
+                    server_id: &[10, 1, 76, 71, 90, 0, 3, 169, 198, 38],
+                    number: AttentionNumber::HintNumber(HintNumber::Positive),
+                    msg: None,
+                    details: Some(Tree {
+                        parameter_name: &[0x01, 0x00, 0x5E, 0x31, 0x00, 0x07, 0x00, 0x01, 0x00],
+                        parameter_value: None,
+                        child_list: Box::new(None),
+                    }),
+                }),
+            },
+            MessageStart {
+                transaction_id: &[3],
+                group_no: 0,
+                abort_on_error: 0,
+                message_body: MessageBody::CloseResponse(CloseResponse {
+                    global_signature: None,
+                }),
+            },
+        ];
+        let mut decoder =
+            sml_rs::transport::decode_streaming::<sml_rs::util::ArrayBuf<2048>>(bytes);
+        while let Some(result) = decoder.next() {
+            let input = result.unwrap();
+            let parser = streaming::Parser::new(input);
+            for (idx, val) in parser.enumerate().into_iter() {
+                if let Ok(ParseEvent::MessageStart(val)) = val {
+                    assert_eq!(expected_response[idx], val);
+                }
+            }
+        }
+    }
+}

--- a/tests/libsml-testing.rs
+++ b/tests/libsml-testing.rs
@@ -126,7 +126,7 @@ mod test_attention_response {
                     details: Some(Tree {
                         parameter_name: &[0x01, 0x00, 0x5E, 0x31, 0x00, 0x07, 0x00, 0x01, 0x00],
                         parameter_value: None,
-                        child_list: Box::new(None),
+                        child_list: None,
                     }),
                 }),
             },
@@ -189,7 +189,7 @@ mod test_attention_response {
                     details: Some(Tree {
                         parameter_name: &[0x01, 0x00, 0x5E, 0x31, 0x00, 0x07, 0x00, 0x01, 0x00],
                         parameter_value: None,
-                        child_list: Box::new(None),
+                        child_list: None,
                     }),
                 }),
             },


### PR DESCRIPTION
This Pull Request enhances the functionality of the sml-rs crate by adding the ability to parse SML Attentions. The new feature allows users to efficiently handle and process SML Attentions, improving the crate's overall utility and flexibility in handling SML data.